### PR TITLE
Proper XML generation using Nokogiri

### DIFF
--- a/lib/linked_in/message.rb
+++ b/lib/linked_in/message.rb
@@ -2,15 +2,17 @@ module LinkedIn
   class Message
 
     attr_accessor :subject, :body, :recipients
-
+  
     def to_xml
-%Q{<mailbox-item>
-  <recipients>
-    #{recipients.to_xml}
-  </recipients>
-  <subject>#{subject}</subject>
-  <body>#{body}</body>
-</mailbox-item>}
+      self.to_xml_node(Nokogiri.XML('<root/>', nil, 'UTF-8')).to_xml
+    end
+
+    def to_xml_node(doc)
+      node = Nokogiri::XML::DocumentFragment.new(doc, '<mailbox-item><recipients/><subject/><body/></mailbox-item>')
+      node.at_css('recipients').add_child(self.recipients.to_xml_nodes(doc))
+      node.at_css('subject').content = self.subject
+      node.at_css('body').content = self.body
+      node
     end
 
   end

--- a/lib/linked_in/recipients.rb
+++ b/lib/linked_in/recipients.rb
@@ -4,9 +4,14 @@ module LinkedIn
     attr_accessor :recipients
 
     def to_xml
-      recipients.inject('') do |result, recipient|
-        result << %Q{<recipient><person path="#{recipient.person.path}"/></recipient>}
-        result
+      self.to_xml_nodes(Nokogiri.XML('<root/>', nil, 'UTF-8')).to_xml
+    end
+    
+    def to_xml_nodes(doc)
+      recipients.inject(Nokogiri::XML::NodeSet.new(doc)) do |nodes, recipient|
+        node = Nokogiri::XML::DocumentFragment.new(doc, '<recipient><person/></recipient>')
+        node.at_css('person')['path'] = recipient.person.path
+        nodes << node
       end
     end
   end

--- a/lib/linked_in/to_xml_helpers.rb
+++ b/lib/linked_in/to_xml_helpers.rb
@@ -1,46 +1,44 @@
 module LinkedIn
   module ToXmlHelpers
 
-    XML_HEADER = %Q{<?xml version="1.0" encoding="UTF-8"?>}
-
     private
 
     def status_to_xml(status)
-      %Q{#{XML_HEADER}\n<current-status>#{status}</current-status>}
+      doc = Nokogiri.XML('<current-status/>', nil, 'UTF-8')
+      doc.root.content = status
+      doc.to_xml
     end
 
     def message_to_xml(message)
-      %Q{#{XML_HEADER}\n#{message.to_xml}}
+      doc = Nokogiri.XML('')
+      doc.encoding = 'UTF-8'
+      doc.root = message.to_xml_node(doc)
+      doc.to_xml
     end
 
     def share_to_xml(options={})
-%Q{#{XML_HEADER}
-<share>
-  <comment>#{options[:comment] if options[:comment]}</comment>
-  <content>
-    <title>#{options[:title] if options[:title]}</title>
-    <submitted-url>#{options[:url] if options[:url]}</submitted-url>
-    <submitted-image-url>#{options[:image_url] if options[:image_url]}</submitted-image-url>
-  </content>
-  <visibility>
-    <code>#{options[:visability]}</code>
-  </visibility>
-</share>}
+      doc = Nokogiri.XML('<share><comment/><title/><submitted-url/><submitted-image-url/><visibility><code/></visibility></share>', nil, 'UTF-8')
+
+      {:comment => 'comment', :title => 'title', :url => 'submitted-url', :image_url => 'submitted-image-url'}.each do |key, name|
+        doc.at_css(name).content = options[key] if options[key]
+      end
+
+      doc.at_css('visibility > code').content = options[:visibility] || options[:visability] # backward-compatible typo fix
+
+      doc.to_xml
     end
 
     def comment_to_xml(comment)
-%Q{#{XML_HEADER}
-<update-comment>
-  <comment>#{comment}</comment>
-</update-comment>}
+      doc = Nokogiri.XML('<update-comment><comment/><update-comment/>', nil, 'UTF-8')
+      doc.at_css('comment').content = comment
+
+      doc.to_xml
     end
 
     def network_update_to_xml(message)
-%Q{#{XML_HEADER}
-<activity locale="en_US">
-  <content-type>linkedin-html</content-type>
-  <body>#{message}</body>
-</activity>}
+      doc = Nokogiri::XML('<activity locale="en_US"><content-type>linkedin-html</content-type><body/></activity>', nil, 'UTF-8')
+      doc.at_css('body').content = message
+      doc.to_xml
     end
 
   end


### PR DESCRIPTION
Hi,

we've hit a bump with strings not being escaped in XML requests (https://github.com/pengwynn/linkedin/issues#issue/36), and I proposed that all XML should be generated with Nokogiri. So, here's a quick fix.

The primary reason for that is using an XML generator, instead of splicing variables into a string, guarantees that you won't have escaping or encoding issues. Ever.

I would use Builder in an app, but to avoid an excess dependency, and since you're already using Nokogiri, it's not much of a difference.
