### PR TITLE
fix module namespacing for exception classes

### DIFF
--- a/lib/linked_in/errors.rb
+++ b/lib/linked_in/errors.rb
@@ -1,20 +1,19 @@
 module LinkedIn
-
-  class LinkedInError < StandardError
-    attr_reader :data
-
-    def initialize(data)
-      @data = data
-      super
+  module Errors
+    class LinkedInError < StandardError
+      attr_reader :data
+      def initialize(data)
+        @data = data
+        super
+      end
     end
+
+    class RateLimitExceededError < LinkedInError; end
+    class UnauthorizedError      < LinkedInError; end
+    class GeneralError           < LinkedInError; end
+
+    class UnavailableError       < StandardError; end
+    class InformLinkedInError    < StandardError; end
+    class NotFoundError          < StandardError; end
   end
-
-  class RateLimitExceededError < LinkedInError; end
-  class UnauthorizedError      < LinkedInError; end
-  class GeneralError           < LinkedInError; end
-
-  class UnavailableError       < StandardError; end
-  class InformLinkedInError    < StandardError; end
-  class NotFoundError          < StandardError; end
-
 end

--- a/lib/linked_in/helpers/request.rb
+++ b/lib/linked_in/helpers/request.rb
@@ -43,16 +43,16 @@ module LinkedIn
           case response.code.to_i
           when 401
             data = Mash.from_json(response.body)
-            raise UnauthorizedError.new(data), "(#{data.status}): #{data.message}"
+            raise LinkedIn::Errors::UnauthorizedError.new(data), "(#{data.status}): #{data.message}"
           when 400, 403
             data = Mash.from_json(response.body)
-            raise GeneralError.new(data), "(#{data.status}): #{data.message}"
+            raise LinkedIn::Errors::GeneralError.new(data), "(#{data.status}): #{data.message}"
           when 404
-            raise NotFoundError, "(#{response.code}): #{response.message}"
+            raise LinkedIn::Errors::NotFoundError, "(#{response.code}): #{response.message}"
           when 500
-            raise InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{response.code}): #{response.message}"
+            raise LinkedIn::Errors::InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{response.code}): #{response.message}"
           when 502..503
-            raise UnavailableError, "(#{response.code}): #{response.message}"
+            raise LinkedIn::Errors::UnavailableError, "(#{response.code}): #{response.message}"
           end
         end
 


### PR DESCRIPTION
The `autoload` in `lib/linkedin.rb` expects the error classes to be defined under the `LinkedIn::Errors` namespace. Yet, they weren't. As a result, `LinkedIn::Helpers::Request.raise_errors` would raise a "NameError: uninitalized constant ..." instead of raising the _real_ error.

All specs still pass after this commit.
