### PR TITLE
Allow "count" and "start" string parameters for pagination of API results

### DIFF
--- a/lib/linked_in/api/query_methods.rb
+++ b/lib/linked_in/api/query_methods.rb
@@ -36,9 +36,9 @@ module LinkedIn
 
           if options[:count] or options[:start]
             path += "?"
-            path += "count=#{CGI::escape(options[:count])}" if options[:count]
+            path += "count=#{options[:count].to_i}" if options[:count]
             path += "&" if options[:count] and options[:start]
-            path += "start=#{CGI::escape(options[:start])}" if options[:start]
+            path += "start=#{options[:start].to_i}" if options[:start]
           end
 
           Mash.from_json(get(path))


### PR DESCRIPTION
The latest version of the LinkedIn API allows you to specify `count` and `start` query string parameters to allow for pagination of results (e.g. for calls to the Connections API). I've allowed the user to pass these two parameters in the `options` hash as one would expect.
