### PR TITLE
Search#field_selector does not modify parameter object

### DIFF
--- a/lib/linked_in/search.rb
+++ b/lib/linked_in/search.rb
@@ -36,7 +36,7 @@ module LinkedIn
 
       def field_selector(fields)
         result = ":("
-        fields.to_a.map! do |field|
+        fields = fields.to_a.map do |field|
           if field.is_a?(Hash)
             innerFields = []
             field.each do |key, value|

--- a/spec/cases/search_spec.rb
+++ b/spec/cases/search_spec.rb
@@ -113,6 +113,15 @@ describe LinkedIn::Search do
       end
     end
 
+    describe "#field_selector" do
+      it "should not modify the parameter object" do
+        fields = [{:people => [:id, :first_name]}]
+        fields_dup = fields.dup
+        client.send(:field_selector, fields)
+        fields.should eq fields_dup
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
I noticed that #field_selector was trying to modify the frozen constant I was passing in. I think this behaviour is definitely not desired, because it is quite likely to keep the field names for search as a constant.
