### PR TITLE
Remove unused error class

### DIFF
--- a/lib/linked_in/errors.rb
+++ b/lib/linked_in/errors.rb
@@ -8,7 +8,6 @@ module LinkedIn
       end
     end
 
-    class RateLimitExceededError < LinkedInError; end
     class UnauthorizedError      < LinkedInError; end
     class GeneralError           < LinkedInError; end
 


### PR DESCRIPTION
It looks like GeneralError class is used for throttle limits
`LinkedIn::Errors::GeneralError: (403): Throttle limit for calls to this resource is reached.`
