### PR TITLE
Api::QueryMethods#simple_query should respect optional request parameters

### DIFF
--- a/lib/linked_in/api/query_methods.rb
+++ b/lib/linked_in/api/query_methods.rb
@@ -43,10 +43,10 @@ module LinkedIn
 
         def person_path(options)
           path = "/people/"
-          if options[:id]
-            path += "id=#{options[:id]}"
-          elsif options[:url]
-            path += "url=#{CGI.escape(options[:url])}"
+          if id = options.delete(:id)
+            path += "id=#{id}"
+          elsif url = options.delete(:url)
+            path += "url=#{CGI.escape(url)}"
           else
             path += "~"
           end
@@ -54,14 +54,14 @@ module LinkedIn
 
         def company_path(options)
           path = "/companies/"
-          if options[:id]
-            path += "id=#{options[:id]}"
-          elsif options[:url]
-            path += "url=#{CGI.escape(options[:url])}"
-          elsif options[:name]
-            path += "universal-name=#{CGI.escape(options[:name])}"
-          elsif options[:domain]
-            path += "email-domain=#{CGI.escape(options[:domain])}"
+          if id = options.delete(:id)
+            path += "id=#{id}"
+          elsif url = options.delete(:url)
+            path += "url=#{CGI.escape(url)}"
+          elsif name = options.delete(:name)
+            path += "universal-name=#{CGI.escape(name)}"
+          elsif domain = options.delete(:domain)
+            path += "email-domain=#{CGI.escape(domain)}"
           else
             path += "~"
           end


### PR DESCRIPTION
This is a very simple fix... it would be better if QueryMethods checked against the allowable parameters for each type of request.

Fixes #95
