### PR TITLE
Support custom url parameters

### DIFF
--- a/lib/linked_in/api/query_methods.rb
+++ b/lib/linked_in/api/query_methods.rb
@@ -33,6 +33,7 @@ module LinkedIn
           elsif fields
             path +=":(#{fields.map{ |f| f.to_s.gsub("_","-") }.join(',')})"
           end
+          path = to_uri(path, options[:parameters])
           headers = options[:headers] || {}
           Mash.from_json(get(path, headers))
         end


### PR DESCRIPTION
For retrieving connections, the default is to return 500 connections. To get more, we need to send custom parameters as part of the path.

See Parameters section of https://developer.linkedin.com/documents/connections-api
