### PR TITLE
Return AccessDeniedError when linkedin returns 403 HTTP status code

### DIFF
--- a/lib/linked_in/errors.rb
+++ b/lib/linked_in/errors.rb
@@ -10,6 +10,7 @@ module LinkedIn
 
     class UnauthorizedError      < LinkedInError; end
     class GeneralError           < LinkedInError; end
+    class AccessDeniedError      < LinkedInError; end
 
     class UnavailableError       < StandardError; end
     class InformLinkedInError    < StandardError; end

--- a/lib/linked_in/helpers/request.rb
+++ b/lib/linked_in/helpers/request.rb
@@ -44,9 +44,12 @@ module LinkedIn
           when 401
             data = Mash.from_json(response.body)
             raise LinkedIn::Errors::UnauthorizedError.new(data), "(#{data.status}): #{data.message}"
-          when 400, 403
+          when 400
             data = Mash.from_json(response.body)
             raise LinkedIn::Errors::GeneralError.new(data), "(#{data.status}): #{data.message}"
+          when 403
+            data = Mash.from_json(response.body)
+            raise LinkedIn::Errors::AccessDeniedError.new(data), "(#{data.status}): #{data.message}"
           when 404
             raise LinkedIn::Errors::NotFoundError, "(#{response.code}): #{response.message}"
           when 500

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -83,4 +83,10 @@ describe LinkedIn::Api do
     end
   end
 
+  context "Errors" do
+    it "should raise AccessDeniedError when LinkedIn returns 403 status code" do
+      stub_request(:get, "https://api.linkedin.com/v1/people-search?first-name=Javan").to_return(:body => "{}", :status => 403)
+      expect{ client.search(:first_name => "Javan") }.to raise_error(LinkedIn::Errors::AccessDeniedError)
+    end
+  end
 end


### PR DESCRIPTION
This error class replaces the GeneralError class that was used when Linkedin API returns 403.
