### PR TITLE
Issue with sinatra example

### DIFF
--- a/examples/sinatra.rb
+++ b/examples/sinatra.rb
@@ -7,7 +7,7 @@ enable :sessions
 
 helpers do
   def login?
-    session[:atoken].nil?
+    !session[:atoken].nil?
   end
   
   def profile


### PR DESCRIPTION
The sinatra example login helper was incorrectly checking if the user was logged in or not. This would cause / to always redirect to /auth
