### PR TITLE
Loosen Dependencies in Gemspec

### DIFF
--- a/linkedin.gemspec
+++ b/linkedin.gemspec
@@ -2,9 +2,9 @@
 require File.expand_path('../lib/linked_in/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'hashie', '~> 1.2.0'
-  gem.add_dependency 'multi_json', '~> 1.0.3'
-  gem.add_dependency 'oauth', '~> 0.4.5'
+  gem.add_dependency 'hashie', '~> 1.2'
+  gem.add_dependency 'multi_json', '~> 1.0'
+  gem.add_dependency 'oauth', '~> 0.4'
   gem.add_development_dependency 'json', '~> 1.6'
   gem.add_development_dependency 'rake', '~> 0.9'
   gem.add_development_dependency 'rdoc', '~> 3.8'


### PR DESCRIPTION
We're seeing a few dependency issues down the line with other gems, especially the ones that require multi_json ~> 1.3, which makes ~> 1.0 (the change) happy, but bails on ~> 1.0.3 (the current version specified.)  This fix just lets those other gems coexist.
