### PR TITLE
Allow newer multi_json version

### DIFF
--- a/linkedin.gemspec
+++ b/linkedin.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/linked_in/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.add_dependency 'hashie', '~> 1.2.0'
-  gem.add_dependency 'multi_json', '~> 1.0.3'
+  gem.add_dependency 'multi_json', '>= 1.0.3'
   gem.add_dependency 'oauth', '~> 0.4.5'
   gem.add_development_dependency 'json', '~> 1.6'
   gem.add_development_dependency 'rake', '~> 0.9'


### PR DESCRIPTION
This gem was previously locking in an outdated multi_json version, which was preventing other gems from updating for us because they were locking in a newer version. This change allows newer versions. The test cases run fine and this works in our own usage.

If you merge this, please also release a new version so I can switch back to tracking the official gem. Thanks.
