### PR TITLE
Basic support for Groups API

### DIFF
--- a/lib/linked_in/api/query_methods.rb
+++ b/lib/linked_in/api/query_methods.rb
@@ -23,6 +23,11 @@ module LinkedIn
         simple_query(path, options)
       end
 
+      def group_memberships(options = {})
+        path = "#{person_path(options)}/group-memberships"
+        simple_query(path, options)
+      end
+
       private
 
         def simple_query(path, options={})
@@ -33,7 +38,7 @@ module LinkedIn
           elsif fields
             path +=":(#{fields.map{ |f| f.to_s.gsub("_","-") }.join(',')})"
           end
-          
+
           headers = options.delete(:headers) || {}
           params  = options.map { |k,v| "#{k}=#{v}" }.join("&")
           path   += "?#{params}" if not params.empty?

--- a/lib/linked_in/api/update_methods.rb
+++ b/lib/linked_in/api/update_methods.rb
@@ -9,6 +9,12 @@ module LinkedIn
         post(path, defaults.merge(share).to_json, "Content-Type" => "application/json")
       end
 
+      def join_group(group_id)
+        path = "/people/~/group-memberships/#{group_id}"
+        body = {'membership-state' => {'code' => 'member' }}
+        put(path, body.to_json, "Content-Type" => "application/json")
+      end
+
       # def share(options={})
       #   path = "/people/~/shares"
       #   defaults = { :visability => 'anyone' }

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -83,6 +83,23 @@ describe LinkedIn::Api do
     end
   end
 
+  context "Group API" do
+
+    it "should be able to list group memberships for a profile" do
+      stub_request(:get, "https://api.linkedin.com/v1/people/~/group-memberships").to_return(:body => "{}")
+      client.group_memberships.should be_an_instance_of(LinkedIn::Mash)
+    end
+
+    it "should be able to join a group" do
+      stub_request(:put, "https://api.linkedin.com/v1/people/~/group-memberships/123").to_return(:body => "", :status => 201)
+
+      response = client.join_group(123)
+      response.body.should == ""
+      response.code.should == "201"
+    end
+
+  end
+
   context "Errors" do
     it "should raise AccessDeniedError when LinkedIn returns 403 status code" do
       stub_request(:get, "https://api.linkedin.com/v1/people-search?first-name=Javan").to_return(:body => "{}", :status => 403)


### PR DESCRIPTION
I've added initial support for the groups API to the gem. Right now it just supports listing the group memberships of a particular user, and joining a group by specifying the ID. 

New Calls:
### List group memberships

```
client.group_memberships    # Returns an array of group memberships
```
### Join a group

```
client.join_group([group_id])  # Returns 200 or 201 OK.
```

The specs are pretty basic but follow the convention of most of the specs already in the project.
