### PR TITLE
Added a method to get a user's shares

### DIFF
--- a/lib/linked_in/api/query_methods.rb
+++ b/lib/linked_in/api/query_methods.rb
@@ -27,6 +27,11 @@ module LinkedIn
         path = "#{person_path(options)}/group-memberships"
         simple_query(path, options)
       end
+      
+      def shares(options={})
+        path = "#{person_path(options)}/network/updates?type=SHAR&scope=self"
+        simple_query(path, options)
+      end
 
       private
 


### PR DESCRIPTION
I couldn't find any way of getting the client's shares, so I added a method into query_methods. Should work by just doing

client.shares

(Make sure you've shared an update on your LinkedIn home page first)
