### PR TITLE
Manipulating comments/likes for network_updates ('shares')

### DIFF
--- a/lib/linked_in/api/query_methods.rb
+++ b/lib/linked_in/api/query_methods.rb
@@ -33,6 +33,16 @@ module LinkedIn
         simple_query(path, options)
       end
 
+      def share_comments(update_key, options={})
+        path = "#{person_path(options)}/network/updates/key=#{update_key}/update-comments"
+        simple_query(path, options)
+      end
+
+      def share_likes(update_key, options={})
+        path = "#{person_path(options)}/network/updates/key=#{update_key}/likes"
+        simple_query(path, options)
+      end
+
       private
 
         def simple_query(path, options={})

--- a/lib/linked_in/api/update_methods.rb
+++ b/lib/linked_in/api/update_methods.rb
@@ -32,6 +32,17 @@ module LinkedIn
       #   post(path, network_update_to_xml(message))
       # end
       #
+
+      def like_share(network_key)
+        path = "/people/~/network/updates/key=#{network_key}/is-liked"
+        put(path, 'true', "Content-Type" => "application/json")
+      end
+
+      def unlike_share(network_key)
+        path = "/people/~/network/updates/key=#{network_key}/is-liked"
+        put(path, 'false', "Content-Type" => "application/json")
+      end
+
       def send_message(subject, body, recipient_paths)
         path = "/people/~/mailbox"
       

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -29,6 +29,16 @@ describe LinkedIn::Api do
     stub_request(:get, "https://api.linkedin.com/v1/people/~/network/updates").to_return(:body => "{}")
     client.network_updates.should be_an_instance_of(LinkedIn::Mash)
   end
+  
+  it "should be able to view network_update's comments" do
+    stub_request(:get, "https://api.linkedin.com/v1/people/~/network/updates/key=network_update_key/update-comments").to_return(:body => "{}")
+    client.share_comments("network_update_key").should be_an_instance_of(LinkedIn::Mash)
+  end
+  
+  it "should be able to view network_update's likes" do
+    stub_request(:get, "https://api.linkedin.com/v1/people/~/network/updates/key=network_update_key/likes").to_return(:body => "{}")
+    client.share_likes("network_update_key").should be_an_instance_of(LinkedIn::Mash)
+  end
 
   it "should be able to search with a keyword if given a String" do
     stub_request(:get, "https://api.linkedin.com/v1/people-search?keywords=business").to_return(:body => "{}")
@@ -67,8 +77,22 @@ describe LinkedIn::Api do
     response.body.should == ""
     response.code.should == "201"
   end
-
-
+  
+  it "should be able to like a network update" do
+    stub_request(:put, "https://api.linkedin.com/v1/people/~/network/updates/key=SOMEKEY/is-liked").
+      with(:body => "true").to_return(:body => "", :status => 201)
+    response = client.like_share('SOMEKEY')
+    response.body.should == nil
+    response.code.should == "201"
+  end
+  
+  it "should be able to unlike a network update" do
+    stub_request(:put, "https://api.linkedin.com/v1/people/~/network/updates/key=SOMEKEY/is-liked").
+      with(:body => "false").to_return(:body => "", :status => 201)
+    response = client.unlike_share('SOMEKEY')
+    response.body.should == nil
+    response.code.should == "201"
+  end
 
   context "Company API" do
     use_vcr_cassette


### PR DESCRIPTION
This lacks a method to delete a comment, but it's not available in API itself:

https://developer.linkedin.com/forum/cannot-delete-share-comment-httpapilinkedincom80v1commentsid
