### PR TITLE
Implement JSAPI token to OAuth token conversion.

### DIFF
--- a/lib/linked_in/errors.rb
+++ b/lib/linked_in/errors.rb
@@ -15,5 +15,9 @@ module LinkedIn
     class UnavailableError       < StandardError; end
     class InformLinkedInError    < StandardError; end
     class NotFoundError          < StandardError; end
+
+    class InvalidSignatureError  < LinkedInError; end
+    class UnknownVersionError    < LinkedInError; end
+    class MissingParameterError  < LinkedInError; end
   end
 end


### PR DESCRIPTION
This method implements the conversion (and signature validation) of token-containing cookies returned via LinkedIn's JSAPI to long-lived OAuth tokens. This conversion/validation is [detailed here](https://developer.linkedin.com/documents/exchange-jsapi-tokens-rest-api-oauth-tokens).

It is highly likely that OAuth provides a higher-level method than `request` that is more appropriate, but I chose to follow this route after `get_access_token` proved troublesome.

I have not written any tests for this and I don't have plans to. I don't expect this will be pulled as-is because of that, but am submitting a pull request so that anyone interested in using/improving this has a chance of finding it.

Usage example:

```
client = LinkedIn::Client.new(api_key, api_secret)
client.authorize_from_jsapi_cookie(cookies["linkedin_oauth_#{api_key}"])
```
