### PR TITLE
Passes full set of request_token parameters

### DIFF
--- a/lib/linked_in/helpers/authorization.rb
+++ b/lib/linked_in/helpers/authorization.rb
@@ -18,8 +18,15 @@ module LinkedIn
       # Note: If using oauth with a web app, be sure to provide :oauth_callback.
       # Options:
       #   :oauth_callback => String, url that LinkedIn should redirect to
-      def request_token(options={})
-        @request_token ||= consumer.get_request_token(options)
+      #
+      # If site-specific parameters need to be passed in, they can be passed as
+      # follows:
+      # 
+      # client.request_token({:oauth_callback =>
+      #                                  "http://#{request.host_with_port}/test/callback"},
+      #    :scope => 'r_contactinfo r_network')
+      def request_token(options={}, *arguments, &block)
+        @request_token ||= consumer.get_request_token(options={}, *arguments, &block)
       end
 
       # For web apps use params[:oauth_verifier], for desktop apps,

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -5,6 +5,7 @@ describe "LinkedIn::Client" do
   let(:client) do
     key    = ENV['LINKED_IN_CONSUMER_KEY'] || '1234'
     secret = ENV['LINKED_IN_CONSUMER_SECRET'] || '1234'
+    
     LinkedIn::Client.new(key, secret)
   end
 
@@ -110,6 +111,21 @@ describe "LinkedIn::Client" do
         request_token.authorize_url.should include("https://www.linkedin.com/uas/oauth/authorize?oauth_token=")
         request_token.callback_confirmed?.should == true
 
+        a_request(:post, "https://api.linkedin.com/uas/oauth/requestToken").should have_been_made.once
+      end
+    end
+
+    describe "with a custom parameter" do
+      use_vcr_cassette :record => :new_episodes
+    
+      it "should return a valid access token" do
+        request_token = client.request_token({:oauth_callback => 'http://www.josh.com'},
+          :scope => 'r_contactinfo r_network')
+    
+        request_token.should be_a_kind_of OAuth::RequestToken
+        request_token.authorize_url.should include("https://www.linkedin.com/uas/oauth/authorize?oauth_token=")
+        request_token.callback_confirmed?.should == true
+    
         a_request(:post, "https://api.linkedin.com/uas/oauth/requestToken").should have_been_made.once
       end
     end


### PR DESCRIPTION
The LinkedIn::Helpers::Authorization.request_token function did not pass the full set of parameters to the OAuth::Consumer's request_token function even though it was just a pass through.

This was causing issues with requesting additional scope parameters from LinkedIn.

This commit adds a new spec to test that things still work with the additional parameters,
but it does not contain a new VCR cassette since I don't have the keys used to generate
the existing requests.  This needs to be added.

I'd like to also test the the scope is actually sent, but I don't currently have the time
to lookup the required functions in the HTTP object.
