### PR TITLE
Added functionality for selecting the scope of a token

### DIFF
--- a/lib/linked_in/version.rb
+++ b/lib/linked_in/version.rb
@@ -3,7 +3,7 @@ module LinkedIn
   module VERSION #:nodoc:
     MAJOR = 0
     MINOR = 3
-    PATCH = 7
+    PATCH = 8
     PRE   = nil
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')
   end

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -20,6 +20,13 @@ describe "LinkedIn::Client" do
       end
     end
 
+    describe "request token with scope" do
+      let(:consumer) {client.consumer({:scope => "r_fullprofile"})}
+      it 'should return a request token with scope' do
+        consumer.request_token_url.should == 'https://api.linkedin.com/uas/oauth/requestToken?scope=r_fullprofile'
+      end
+    end
+
     describe "different api and auth hosts options" do
       let(:consumer) do
         LinkedIn::Client.new('1234', '1234', {


### PR DESCRIPTION
Added the functionality for selecting the scope of the token.

Example: 

client = LinkedIn::Client.new(LNKD_API[:api_key],LNKD_API[:api_secret])
request_token = client.request_token({:oauth_callback => "URL",
                                          :scope => 'r_fullprofile+r_emailaddress'}) 
