### PR TITLE
Bump hashie version

### DIFF
--- a/linkedin.gemspec
+++ b/linkedin.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../lib/linked_in/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'hashie', '~> 1.2'
+  gem.add_dependency 'hashie', ['>= 1.2', '< 2.1']
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'oauth', '~> 0.4'
   gem.add_development_dependency 'json', '~> 1.6'


### PR DESCRIPTION
Hashie is now on major version 2.0, with new features that I'd like to embrace in my application. Pessimistic version locking is preventing that.
