### PR TITLE
Add option to specify a proxy

### DIFF
--- a/lib/linked_in/helpers/authorization.rb
+++ b/lib/linked_in/helpers/authorization.rb
@@ -48,7 +48,8 @@ module LinkedIn
             :request_token_url => full_oauth_url_for(:request_token, :api_host),
             :access_token_url  => full_oauth_url_for(:access_token,  :api_host),
             :authorize_url     => full_oauth_url_for(:authorize,     :auth_host),
-            :site              => @consumer_options[:site] || @consumer_options[:api_host] || DEFAULT_OAUTH_OPTIONS[:api_host]
+            :site              => @consumer_options[:site] || @consumer_options[:api_host] || DEFAULT_OAUTH_OPTIONS[:api_host],
+            :proxy             => @consumer_options.fetch(:proxy, nil)
           }
         end
 

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -20,6 +20,19 @@ describe "LinkedIn::Client" do
       end
     end
 
+    describe "proxy oauth options" do
+      let(:proxy) { "http://dummy.proxy" }
+      let(:consumer) do
+        LinkedIn::Client.new('1234', '1234', {
+          :proxy => proxy,
+        }).consumer
+      end
+
+      it "should send requests though proxy" do
+        consumer.proxy.should eq proxy
+      end
+    end
+
     describe "different api and auth hosts options" do
       let(:consumer) do
         LinkedIn::Client.new('1234', '1234', {


### PR DESCRIPTION
It was not possible to use linkedin gem behind the proxy.
