### PR TITLE
Implemented the Job API

### DIFF
--- a/lib/linked_in/api/query_methods.rb
+++ b/lib/linked_in/api/query_methods.rb
@@ -23,6 +23,21 @@ module LinkedIn
         simple_query(path, options)
       end
 
+      def job(options = {})
+        path = jobs_path(options)
+        simple_query(path, options)
+      end
+
+      def job_bookmarks(options = {})
+        path = "#{person_path(options)}/job-bookmarks"
+        simple_query(path, options)
+      end
+
+      def job_suggestions(options = {})
+        path = "#{person_path(options)}/suggestions/job-suggestions"
+        simple_query(path, options)
+      end
+
       def group_memberships(options = {})
         path = "#{person_path(options)}/group-memberships"
         simple_query(path, options)
@@ -83,6 +98,15 @@ module LinkedIn
             path += "/url=#{CGI.escape(url)}"
           elsif name = options.delete(:name)
             path += "/universal-name=#{CGI.escape(name)}"
+          else
+            path += "/~"
+          end
+        end
+
+        def jobs_path(options)
+          path = "/jobs"
+          if id = options.delete(:id)
+            path += "/id=#{id}"
           else
             path += "/~"
           end

--- a/lib/linked_in/api/update_methods.rb
+++ b/lib/linked_in/api/update_methods.rb
@@ -15,6 +15,12 @@ module LinkedIn
         put(path, body.to_json, "Content-Type" => "application/json")
       end
 
+      def add_job_bookmark(bookmark)
+        path = "/people/~/job-bookmarks"
+        body = {'job' => {'id' => bookmark}}
+        post(path, body.to_json, "Content-Type" => "application/json")
+      end
+
       # def share(options={})
       #   path = "/people/~/shares"
       #   defaults = { :visability => 'anyone' }

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -136,6 +136,32 @@ describe LinkedIn::Api do
     end
   end
 
+  context "Job API" do
+    use_vcr_cassette
+
+    it "should be able to view a job listing" do
+      stub_request(:get, "https://api.linkedin.com/v1/jobs/id=1586").to_return(:body => "{}")
+      client.job(:id => 1586).should be_an_instance_of(LinkedIn::Mash)
+    end
+
+    it "should be able to view its job bookmarks" do
+      stub_request(:get, "https://api.linkedin.com/v1/people/~/job-bookmarks").to_return(:body => "{}")
+      client.job_bookmarks.should be_an_instance_of(LinkedIn::Mash)
+    end
+
+    it "should be able to view its job suggestion" do
+      stub_request(:get, "https://api.linkedin.com/v1/people/~/suggestions/job-suggestions").to_return(:body => "{}")
+      client.job_suggestions.should be_an_instance_of(LinkedIn::Mash)
+    end
+
+    it "should be able to add a bookmark" do
+      stub_request(:post, "https://api.linkedin.com/v1/people/~/job-bookmarks").to_return(:body => "", :status => 201)
+      response = client.add_job_bookmark(:id => 1452577)
+      response.body.should == nil
+      response.code.should == "201"
+    end
+  end
+
   context "Group API" do
 
     it "should be able to list group memberships for a profile" do


### PR DESCRIPTION
Implemented the Job API. The client is now able to:
- view a job with a specific id.
- view user job bookmarks.
- add a job to user bookmarks.
- view job suggestions.

Did not implement the creation of a new job trough the Linkedin API.

Request https://github.com/pengwynn/linkedin/issues/156
