### PR TITLE
Update field references to "educations"

### DIFF
--- a/lib/linkedin.rb
+++ b/lib/linkedin.rb
@@ -10,7 +10,7 @@ module LinkedIn
     # LinkedIn.configure do |config|
     #   config.token = 'consumer_token'
     #   config.secret = 'consumer_secret'
-    #   config.default_profile_fields = ['education', 'positions']
+    #   config.default_profile_fields = ['educations', 'positions']
     # end
     #
     # elsewhere

--- a/spec/cases/linkedin_spec.rb
+++ b/spec/cases/linkedin_spec.rb
@@ -17,21 +17,21 @@ describe LinkedIn do
   end
 
   it "should be able to set the default profile fields" do
-    LinkedIn.default_profile_fields = ['education', 'positions']
+    LinkedIn.default_profile_fields = ['educations', 'positions']
 
-    LinkedIn.default_profile_fields.should == ['education', 'positions']
+    LinkedIn.default_profile_fields.should == ['educations', 'positions']
   end
 
   it "should be able to set the consumer token and consumer secret via a configure block" do
     LinkedIn.configure do |config|
       config.token  = 'consumer_token'
       config.secret = 'consumer_secret'
-      config.default_profile_fields = ['education', 'positions']
+      config.default_profile_fields = ['educations', 'positions']
     end
 
     LinkedIn.token.should  == 'consumer_token'
     LinkedIn.secret.should == 'consumer_secret'
-    LinkedIn.default_profile_fields.should == ['education', 'positions']
+    LinkedIn.default_profile_fields.should == ['educations', 'positions']
   end
 
 end


### PR DESCRIPTION
"education" isn't a valid field name. Specifying it will yield an error from
LinkedIn: "Unknown field {education} in resource {Person}"

See: http://developer.linkedin.com/documents/profile-fields
