### PR TITLE
Fixed an issue with double ? in the query paramters

### DIFF
--- a/lib/linked_in/api/query_methods.rb
+++ b/lib/linked_in/api/query_methods.rb
@@ -108,7 +108,7 @@ module LinkedIn
 
         headers = options.delete(:headers) || {}
         params  = to_query(options)
-        path   += "?#{params}" if !params.empty?
+        path   += "#{path.include?("?") ? "&" : "?"}#{params}" if !params.empty?
 
         Mash.from_json(get(path, headers))
       end

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -141,6 +141,11 @@ describe LinkedIn::Api do
       client.company(:is_admin => 'true').should be_an_instance_of(LinkedIn::Mash)
     end
 
+    it "should be able to page a user's company pages" do
+      stub_request(:get, "https://api.linkedin.com/v1/companies?is-company-admin=true&count=10&start=0").to_return(:body => "{}")
+      client.company(:is_admin => 'true', :count => 10, :start => 0).should be_an_instance_of(LinkedIn::Mash)
+    end
+
     it "should load correct company data" do
       client.company(:id => 1586).name.should == "Amazon"
 


### PR DESCRIPTION
If you call .company(:is_admin => 'true', :start=>0, :count=>10) the query string ends up being `?is-company-admin=true?start=0&count=10` This patch checks to see if the ? has already been added.
