### PR TITLE
Dont limit group posts to only title and summary

### DIFF
--- a/lib/linked_in/api/update_methods.rb
+++ b/lib/linked_in/api/update_methods.rb
@@ -71,13 +71,7 @@ module LinkedIn
 
       def post_group_discussion(group_id, discussion)
         path = "/groups/#{group_id}/posts"
-
-        discussion_post = {
-          'title' => discussion['title'],
-          'summary' => discussion['summary']
-        }
-
-        post(path, discussion_post.to_json, "Content-Type" => "application/json")
+        post(path, discussion.to_json, "Content-Type" => "application/json")
       end
 
     end

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -250,8 +250,16 @@ describe LinkedIn::Api do
     end
 
     it 'should be able to post a discussion to a group' do
-      stub_request(:post, "https://api.linkedin.com/v1/groups/123/posts").to_return(:body => "", :status => 201)
-      response = client.post_group_discussion(123, {'title' => 'New Discussion', 'summary' => 'New Summary'})
+      expected = {
+        'title' => 'New Discussion',
+        'summary' => 'New Summary',
+        'content' => {
+          "submitted-url" => "http://www.google.com"
+        }
+      }
+
+      stub_request(:post, "https://api.linkedin.com/v1/groups/123/posts").with(:body => expected).to_return(:body => "", :status => 201)
+      response = client.post_group_discussion(123, expected)
       response.body.should == nil
       response.code.should == '201'
     end


### PR DESCRIPTION
The group post can also have a content field as specified here https://developer.linkedin.com/documents/groups-api#
