### PR TITLE
Communication api for using messages was not clear, this will make it clearer

### DIFF
--- a/examples/communication.rb
+++ b/examples/communication.rb
@@ -1,0 +1,7 @@
+# AUTHENTICATE FIRST found in examples/authenticate.rb
+
+# client is a LinkedIn::Client
+
+# send a message to a person in your network. you will need to authenticate the 
+# user and ask for the "w_messages" permission.
+response = client.send_message("subject", "body", ["person_1_id", "person_2_id"])

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -89,13 +89,6 @@ describe LinkedIn::Api do
     response.code.should == "201"
   end
 
-  it "should be able to send a message" do
-    stub_request(:post, "https://api.linkedin.com/v1/people/~/mailbox").to_return(:body => "", :status => 201)
-    response = client.send_message("subject", "body", ["recip1", "recip2"])
-    response.body.should == nil
-    response.code.should == "201"
-  end
-
   it "should be able to like a network update" do
     stub_request(:put, "https://api.linkedin.com/v1/people/~/network/updates/key=SOMEKEY/is-liked").
       with(:body => "true").to_return(:body => "", :status => 201)
@@ -267,6 +260,15 @@ describe LinkedIn::Api do
       response = client.post_group_discussion(123, expected)
       response.body.should == nil
       response.code.should == '201'
+    end
+  end
+
+  context "Communication API" do
+    it "should be able to send a message" do
+      stub_request(:post, "https://api.linkedin.com/v1/people/~/mailbox").to_return(:body => "", :status => 201)
+      response = client.send_message("subject", "body", ["recip1", "recip2"])
+      response.body.should == nil
+      response.code.should == "201"
     end
   end
 


### PR DESCRIPTION
Added an example for the communication API using the messages.
Moved the message test spec under the right context.
