### PR TITLE
Add ability to send targeted company shares

### DIFF
--- a/lib/linked_in/api/update_methods.rb
+++ b/lib/linked_in/api/update_methods.rb
@@ -9,10 +9,26 @@ module LinkedIn
         post(path, defaults.merge(share).to_json, "Content-Type" => "application/json")
       end
 
+      # Creates a company share
+      # 
+      # Returns an HttpResponse object with a body containing update_key and update_url
+      # 
+      # @param company_id [String] The company id
+      # @param share [Hash] Share data
+      # 
+      # @option share [String] comment  Post must contain comment and/or (content/title and content/submitted-url). Max length is 700 characters.
+      # @option share [Hash] content Content Hash
+      # @option content [String] title Post must contain comment and/or (content/title and content/submitted-url). Max length is 200 characters.
+      # @option content [String] submitted-url Post must contain comment and/or (content/title and content/submitted-url).
+      # @option content [String] submitted-image-url Invalid without (content/title and content/submitted-url).
+      # @option content [String] description Max length of 256 characters.
+      # @option share [Hash] targets Hash containing target_code => ['target_value', ...]
+      # 
+      # @return [HttpResponse] Response
       def add_company_share(company_id, share)
         path = "/companies/#{company_id}/shares"
         defaults = {:visibility => {:code => "anyone"}}
-        post(path, defaults.merge(share).to_json, "Content-Type" => "application/json")
+        hashify post(path, render(:company_share, defaults.merge(share)), 'x-li-format' => 'xml', "Content-Type" => "application/xml")
       end
 
       def follow_company(company_id)
@@ -72,6 +88,13 @@ module LinkedIn
       def post_group_discussion(group_id, discussion)
         path = "/groups/#{group_id}/posts"
         post(path, discussion.to_json, "Content-Type" => "application/json")
+      end
+
+      private
+
+      def hashify response
+        response.body = Mash.from_response response
+        response
       end
 
     end

--- a/lib/linked_in/client.rb
+++ b/lib/linked_in/client.rb
@@ -8,6 +8,7 @@ module LinkedIn
     include Api::QueryMethods
     include Api::UpdateMethods
     include Search
+    include Template
 
     attr_reader :consumer_token, :consumer_secret, :consumer_options
 

--- a/lib/linked_in/helpers/request.rb
+++ b/lib/linked_in/helpers/request.rb
@@ -42,13 +42,13 @@ module LinkedIn
           # in the HTTP answer (thankfully).
           case response.code.to_i
           when 401
-            data = Mash.from_json(response.body)
+            data = Mash.from_response(response)
             raise LinkedIn::Errors::UnauthorizedError.new(data), "(#{data.status}): #{data.message}"
           when 400
-            data = Mash.from_json(response.body)
+            data = Mash.from_response(response)
             raise LinkedIn::Errors::GeneralError.new(data), "(#{data.status}): #{data.message}"
           when 403
-            data = Mash.from_json(response.body)
+            data = Mash.from_response(response)
             raise LinkedIn::Errors::AccessDeniedError.new(data), "(#{data.status}): #{data.message}"
           when 404
             raise LinkedIn::Errors::NotFoundError, "(#{response.code}): #{response.message}"

--- a/lib/linked_in/mash.rb
+++ b/lib/linked_in/mash.rb
@@ -1,5 +1,6 @@
 require 'hashie'
 require 'multi_json'
+require 'multi_xml'
 
 module LinkedIn
   class Mash < ::Hashie::Mash
@@ -8,6 +9,22 @@ module LinkedIn
     def self.from_json(json_string)
       result_hash = ::MultiJson.decode(json_string)
       new(result_hash)
+    end
+
+    # a simple helper to convert an xml string to a Mash
+    def self.from_xml(xml_string)
+      result_hash = ::MultiXml.parse(xml_string)
+
+      # Drop off the root element
+      new(result_hash[result_hash.keys.first])
+    end
+
+    def self.from_response(response)
+      if response['x-li-format'] == 'xml' or /\bxml\b/.match response['Content-Type']
+        from_xml(response.body)
+      else
+        from_json(response.body)
+      end
     end
 
     # returns a Date if we have year, month and day, and no conflicting key

--- a/lib/linked_in/template.rb
+++ b/lib/linked_in/template.rb
@@ -1,0 +1,37 @@
+require 'erb'
+require 'ostruct'
+require 'hashie'
+
+module LinkedIn
+  class TemplateBinding < ::Hashie::Mash
+    include ERB::Util
+  end
+
+  module Template
+
+    class << self
+      cache = {}
+      mutex = Mutex.new
+
+      define_method :load_template do |template|
+        return cache[template] if cache[template]
+        mutex.synchronize do
+          return cache[template] if cache[template]
+
+          file = File.join(LinkedIn.templates, "#{template.to_s}.xml.erb")
+          io = ::IO.respond_to?(:binread) ? ::IO.binread(file) : ::IO.read(file)
+          erb = ERB.new(io)
+          erb.filename = file
+
+          cache[template] = erb
+        end
+      end
+    end
+
+    def render template, data
+      template = Template.load_template template
+      namespace = TemplateBinding.new data
+      template.result namespace.instance_eval { binding }
+    end
+  end
+end

--- a/lib/linked_in/templates/company_share.xml.erb
+++ b/lib/linked_in/templates/company_share.xml.erb
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<share>
+  <visibility>
+    <code><%=h visibility.code%></code>
+  </visibility>
+  <% if comment %>
+  <comment><%= h comment %></comment>
+  <% end %>
+  <% if content %>
+  <content>
+    <% if content["title"] %><title><%= h content["title"] %></title><% end %>
+    <submitted-url><%= h content["submitted-url"] %></submitted-url>
+    <% if content["description"] %><description><%= h content["description"] %></description><% end %>
+    <% if content["submitted-image-url"] %><submitted-image-url><%= h content["submitted-image-url"] %></submitted-image-url><% end %>
+  </content>
+  <% end %>
+  <% if targets %>
+  <share-target-reach>
+    <share-targets>
+    <% targets.each do |key, values| %>
+      <share-target>
+        <code><%= h key %></code>
+        <tvalues>
+          <% values.each do |value| %>
+          <tvalue><%= h value %></tvalue>
+          <% end %>
+        </tvalues>
+      </share-target>
+    <% end %>
+    </share-targets>
+  </share-target-reach>
+  <% end %>
+</share>

--- a/lib/linkedin.rb
+++ b/lib/linkedin.rb
@@ -3,7 +3,7 @@ require 'oauth'
 module LinkedIn
 
   class << self
-    attr_accessor :token, :secret, :default_profile_fields
+    attr_accessor :token, :secret, :default_profile_fields, :templates
 
     # config/initializers/linkedin.rb (for instance)
     #
@@ -22,6 +22,8 @@ module LinkedIn
     end
   end
 
+  @templates = File.join(File.expand_path(File.dirname(__FILE__)), 'linked_in', 'templates')
+
   autoload :Api,     "linked_in/api"
   autoload :Client,  "linked_in/client"
   autoload :Mash,    "linked_in/mash"
@@ -29,4 +31,5 @@ module LinkedIn
   autoload :Helpers, "linked_in/helpers"
   autoload :Search,  "linked_in/search"
   autoload :Version, "linked_in/version"
+  autoload :Template, "linked_in/template"
 end

--- a/linkedin.gemspec
+++ b/linkedin.gemspec
@@ -4,6 +4,7 @@ require File.expand_path('../lib/linked_in/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.add_dependency 'hashie', ['>= 1.2', '< 2.1']
   gem.add_dependency 'multi_json', '~> 1.0'
+  gem.add_dependency 'multi_xml'
   gem.add_dependency 'oauth', '~> 0.4'
   # gem.add_development_dependency 'json', '~> 1.6'
   gem.add_development_dependency 'rake', '~> 10'


### PR DESCRIPTION
This introduces a breaking change to the add_company_share method. We
now parse the response body so the user does not have to parse the xml
response body. This change should not impact many users seeing as the
add_company_share method was just added a while ago and there hasn't
been a release since.

Usage:

```
response = client.add_company_share("2414183", {
  :comment => "Testing, 1, 2, 3",
  :targets => {
    :geos => ['as', 'eu'],
    :jobFunc => ['acct', 'bd']
  }
puts "ID: #{response.body.update_key}"
puts "URL: #{response.body.update_url}"
```
