### PR TITLE
Change LinkedIn::Mash#all to return [] instead of nil when there are no results

### DIFF
--- a/lib/linked_in/mash.rb
+++ b/lib/linked_in/mash.rb
@@ -37,6 +37,10 @@ module LinkedIn
       end
     end
 
+    def all
+      super || []
+    end
+
     protected
 
       def contains_date_fields?

--- a/spec/cases/mash_spec.rb
+++ b/spec/cases/mash_spec.rb
@@ -98,4 +98,16 @@ describe LinkedIn::Mash do
     end
   end
 
+  describe "#all" do
+    let(:all_mash) do
+      LinkedIn::Mash.new({
+        :values => nil
+      })
+    end
+
+    it "should return an empty array if values is nil due to no results being found for a query" do
+      all_mash.all.should == []
+    end
+  end
+
 end


### PR DESCRIPTION
If I call a query method that usually returns an array of results, but no results are found, LinkedIn::Mash.all currently returns nil. It makes more sense logically for it to return an empty array. With this patch, you no longer have to add handle the possiblility of `nil`, such as in this example:

```
client = LinkedIn::Client.new(...)
client.network_updates.all || []
```
