### PR TITLE
changes /authorize path to /authenticate

### DIFF
--- a/lib/linked_in/helpers/authorization.rb
+++ b/lib/linked_in/helpers/authorization.rb
@@ -6,7 +6,7 @@ module LinkedIn
       DEFAULT_OAUTH_OPTIONS = {
         :request_token_path => "/uas/oauth/requestToken",
         :access_token_path  => "/uas/oauth/accessToken",
-        :authorize_path     => "/uas/oauth/authorize",
+        :authorize_path     => "/uas/oauth/authenticate",
         :api_host           => "https://api.linkedin.com",
         :auth_host          => "https://www.linkedin.com"
       }


### PR DESCRIPTION
better to use linkedin's updated /authenticate path so if the user is logged into linkedin and already has an active access_token, a redirect will happen without asking for permission again.

Can change the name of the methods to authenticate and change the spec tests accordingly later.
