### PR TITLE
Port to  OAuth 2

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,6 +1,6 @@
 # Linkedin Gem Examples
 
-## OAuth 1.0a Authentication
+## OAuth2 Authentication
 
 Here's an example of authenticating with the LinkedIn API
 
@@ -13,22 +13,18 @@ client = LinkedIn::Client.new('your_consumer_key', 'your_consumer_secret')
 
 # If you want to use one of the scopes from linkedin you have to pass it in at this point
 # You can learn more about it here: http://developer.linkedin.com/documents/authentication
-request_token = client.request_token({}, :scope => "r_basicprofile+r_emailaddress")
-
-rtoken = request_token.token
-rsecret = request_token.secret
 
 # to test from your desktop, open the following url in your browser
 # and record the pin it gives you
-request_token.authorize_url
-=> "https://api.linkedin.com/uas/oauth/authorize?oauth_token=<generated_token>"
+client.authorize_url(:redirect_uri => 'https:://www.yourdomain.com/callback', :state => SecureRandom.uuid, :scope => "r_basicprofile+r_emailaddress")
+=> "https://api.linkedin.com/uas/oauth2/authorization?"
 
 # then fetch your access keys
-client.authorize_from_request(rtoken, rsecret, pin)
-=> ["OU812", "8675309"] # <= save these for future requests
+client.authorize_from_request(code, :redirect_uri => 'https:://www.yourdomain.com/callback')
+=> "OU812" # <= save this for future requests
 
 # or authorize from previously fetched access keys
-client.authorize_from_access("OU812", "8675309")
+client.authorize_from_access("OU812")
 
 # you're now free to move about the cabin, call any API method
 ```
@@ -145,7 +141,7 @@ helpers do
   private
   def linkedin_client
     client = LinkedIn::Client.new(settings.api, settings.secret)
-    client.authorize_from_access(session[:atoken], session[:asecret])
+    client.authorize_from_access(session[:atoken])
     client
   end
 

--- a/lib/linked_in/helpers/request.rb
+++ b/lib/linked_in/helpers/request.rb
@@ -12,25 +12,25 @@ module LinkedIn
       protected
 
         def get(path, options={})
-          response = access_token.get("#{API_PATH}#{path}", DEFAULT_HEADERS.merge(options))
+          response = access_token.get("#{API_PATH}#{path}", {:headers => DEFAULT_HEADERS.merge(options)})
           raise_errors(response)
           response.body
         end
 
         def post(path, body='', options={})
-          response = access_token.post("#{API_PATH}#{path}", body, DEFAULT_HEADERS.merge(options))
+          response = access_token.post("#{API_PATH}#{path}", {:body => body, :headers => DEFAULT_HEADERS.merge(options)})
           raise_errors(response)
           response
         end
 
         def put(path, body, options={})
-          response = access_token.put("#{API_PATH}#{path}", body, DEFAULT_HEADERS.merge(options))
+          response = access_token.put("#{API_PATH}#{path}", {:body => body, :headers => DEFAULT_HEADERS.merge(options)})
           raise_errors(response)
           response
         end
 
         def delete(path, options={})
-          response = access_token.delete("#{API_PATH}#{path}", DEFAULT_HEADERS.merge(options))
+          response = access_token.delete("#{API_PATH}#{path}", {:headers => DEFAULT_HEADERS.merge(options)})
           raise_errors(response)
           response
         end
@@ -40,7 +40,7 @@ module LinkedIn
         def raise_errors(response)
           # Even if the json answer contains the HTTP status code, LinkedIn also sets this code
           # in the HTTP answer (thankfully).
-          case response.code.to_i
+          case response.status.to_i
           when 401
             data = Mash.from_json(response.body)
             raise LinkedIn::Errors::UnauthorizedError.new(data), "(#{data.status}): #{data.message}"
@@ -51,11 +51,11 @@ module LinkedIn
             data = Mash.from_json(response.body)
             raise LinkedIn::Errors::AccessDeniedError.new(data), "(#{data.status}): #{data.message}"
           when 404
-            raise LinkedIn::Errors::NotFoundError, "(#{response.code}): #{response.message}"
+            raise LinkedIn::Errors::NotFoundError, "(#{response.status}): #{response.message}"
           when 500
-            raise LinkedIn::Errors::InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{response.code}): #{response.message}"
+            raise LinkedIn::Errors::InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{response.status}): #{response.message}"
           when 502..503
-            raise LinkedIn::Errors::UnavailableError, "(#{response.code}): #{response.message}"
+            raise LinkedIn::Errors::UnavailableError, "(#{response.status}): #{response.message}"
           end
         end
 

--- a/lib/linkedin.rb
+++ b/lib/linkedin.rb
@@ -1,4 +1,4 @@
-require 'oauth'
+require 'oauth2'
 
 module LinkedIn
 

--- a/linkedin.gemspec
+++ b/linkedin.gemspec
@@ -4,7 +4,7 @@ require File.expand_path('../lib/linked_in/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.add_dependency 'hashie', '~> 3.0'
   gem.add_dependency 'multi_json', '~> 1.0'
-  gem.add_dependency 'oauth', '~> 0.4'
+  gem.add_dependency 'oauth2', '~> 1.0'
   # gem.add_development_dependency 'json', '~> 1.6'
   gem.add_development_dependency 'rake', '~> 10'
   gem.add_development_dependency 'yard'

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -4,11 +4,11 @@ describe LinkedIn::Api do
   before do
     LinkedIn.default_profile_fields = nil
     client.stub(:consumer).and_return(consumer)
-    client.authorize_from_access('atoken', 'asecret')
+    client.authorize_from_access('77j2rfbjbmkcdh')
   end
 
   let(:client){LinkedIn::Client.new('token', 'secret')}
-  let(:consumer){OAuth::Consumer.new('token', 'secret', {:site => 'https://api.linkedin.com'})}
+  let(:consumer){OAuth2::Client.new('token', 'secret', {:site => 'https://api.linkedin.com', :raise_errors => false})}
 
   it "should be able to view the account profile" do
     stub_request(:get, "https://api.linkedin.com/v1/people/~").to_return(:body => "{}")
@@ -70,15 +70,15 @@ describe LinkedIn::Api do
   it "should be able to share a new status" do
     stub_request(:post, "https://api.linkedin.com/v1/people/~/shares").to_return(:body => "", :status => 201)
     response = client.add_share(:comment => "Testing, 1, 2, 3")
-    response.body.should == nil
-    response.code.should == "201"
+    response.body.should == ""
+    response.status.should == 201
   end
 
   it "should be able to share a new company status" do
     stub_request(:post, "https://api.linkedin.com/v1/companies/123456/shares").to_return(:body => "", :status => 201)
     response = client.add_company_share("123456", { :comment => "Testing, 1, 2, 3" })
-    response.body.should == nil
-    response.code.should == "201"
+    response.body.should == ""
+    response.status.should == 201
   end
 
   it "returns the shares for a person" do
@@ -91,35 +91,24 @@ describe LinkedIn::Api do
     stub_request(:post, "https://api.linkedin.com/v1/people/~/network/updates/key=SOMEKEY/update-comments").to_return(
         :body => "", :status => 201)
     response = client.update_comment('SOMEKEY', "Testing, 1, 2, 3")
-    response.body.should == nil
-    response.code.should == "201"
+    response.body.should == ""
+    response.status.should == 201
   end
 
   it "should be able to like a network update" do
     stub_request(:put, "https://api.linkedin.com/v1/people/~/network/updates/key=SOMEKEY/is-liked").
       with(:body => "true").to_return(:body => "", :status => 201)
     response = client.like_share('SOMEKEY')
-    response.body.should == nil
-    response.code.should == "201"
+    response.body.should == ""
+    response.status.should == 201
   end
 
   it "should be able to unlike a network update" do
     stub_request(:put, "https://api.linkedin.com/v1/people/~/network/updates/key=SOMEKEY/is-liked").
       with(:body => "false").to_return(:body => "", :status => 201)
     response = client.unlike_share('SOMEKEY')
-    response.body.should == nil
-    response.code.should == "201"
-  end
-
-  it "should be able to pass down the additional arguments to OAuth's get_request_token" do
-    consumer.should_receive(:get_request_token).with(
-      {:oauth_callback => "http://localhost:3000/auth/callback"},  :scope => "rw_nus").and_return("request_token")
-
-    request_token = client.request_token(
-      {:oauth_callback => "http://localhost:3000/auth/callback"},  :scope => "rw_nus"
-    )
-
-    request_token.should == "request_token"
+    response.body.should == ""
+    response.status.should == 201
   end
 
   context "Company API", :vcr do
@@ -185,16 +174,16 @@ describe LinkedIn::Api do
       stub_request(:post, "https://api.linkedin.com/v1/people/~/following/companies").to_return(:body => "", :status => 201)
 
       response = client.follow_company(1586)
-      response.body.should == nil
-      response.code.should == "201"
+      response.body.should == ""
+      response.status.should == 201
     end
 
     it "should be able to unfollow a company" do
       stub_request(:delete, "https://api.linkedin.com/v1/people/~/following/companies/id=1586").to_return(:body => "", :status => 201)
 
       response = client.unfollow_company(1586)
-      response.body.should == nil
-      response.code.should == "201"
+      response.body.should == ""
+      response.status.should == 201
     end
 
   end
@@ -219,8 +208,8 @@ describe LinkedIn::Api do
     it "should be able to add a bookmark" do
       stub_request(:post, "https://api.linkedin.com/v1/people/~/job-bookmarks").to_return(:body => "", :status => 201)
       response = client.add_job_bookmark(:id => 1452577)
-      response.body.should == nil
-      response.code.should == "201"
+      response.body.should == ""
+      response.status.should == 201
     end
   end
 
@@ -246,8 +235,8 @@ describe LinkedIn::Api do
       stub_request(:put, "https://api.linkedin.com/v1/people/~/group-memberships/123").to_return(:body => "", :status => 201)
 
       response = client.join_group(123)
-      response.body.should == nil
-      response.code.should == "201"
+      response.body.should == ""
+      response.status.should == 201
     end
 
     it "should be able to list a group profile" do
@@ -273,15 +262,15 @@ describe LinkedIn::Api do
 
       stub_request(:post, "https://api.linkedin.com/v1/groups/123/posts").with(:body => expected).to_return(:body => "", :status => 201)
       response = client.post_group_discussion(123, expected)
-      response.body.should == nil
-      response.code.should == '201'
+      response.body.should == ""
+      response.status.should == 201
     end
 
     it "should be able to share a new group status" do
       stub_request(:post, "https://api.linkedin.com/v1/groups/1/posts").to_return(:body => "", :status => 201)
       response = client.add_group_share(1, :comment => "Testing, 1, 2, 3")
-      response.body.should == nil
-      response.code.should == "201"
+      response.body.should == ""
+      response.status.should == 201
     end
   end
 
@@ -289,8 +278,8 @@ describe LinkedIn::Api do
     it "should be able to send a message" do
       stub_request(:post, "https://api.linkedin.com/v1/people/~/mailbox").to_return(:body => "", :status => 201)
       response = client.send_message("subject", "body", ["recip1", "recip2"])
-      response.body.should == nil
-      response.code.should == "201"
+      response.body.should == ""
+      response.status.should == 201
     end
   end
 

--- a/spec/cases/oauth_spec.rb
+++ b/spec/cases/oauth_spec.rb
@@ -14,22 +14,8 @@ describe "LinkedIn::Client" do
 
       it "should return a configured OAuth consumer" do
         consumer.site.should == 'https://api.linkedin.com'
-        consumer.request_token_url.should == 'https://api.linkedin.com/uas/oauth/requestToken'
-        consumer.access_token_url.should == 'https://api.linkedin.com/uas/oauth/accessToken'
-        consumer.authorize_url.should == 'https://www.linkedin.com/uas/oauth/authorize'
-      end
-    end
-
-    describe "proxy oauth options" do
-      let(:proxy) { "http://dummy.proxy" }
-      let(:consumer) do
-        LinkedIn::Client.new('1234', '1234', {
-          :proxy => proxy,
-        }).consumer
-      end
-
-      it "should send requests though proxy" do
-        consumer.proxy.should eq proxy
+        consumer.token_url.should == 'https://api.linkedin.com/uas/oauth2/accessToken'
+        consumer.authorize_url.should == 'https://www.linkedin.com/uas/oauth2/authorization'
       end
     end
 
@@ -43,43 +29,38 @@ describe "LinkedIn::Client" do
 
       it "should return a configured OAuth consumer" do
         consumer.site.should == 'https://api.josh.com'
-        consumer.request_token_url.should == 'https://api.josh.com/uas/oauth/requestToken'
-        consumer.access_token_url.should == 'https://api.josh.com/uas/oauth/accessToken'
-        consumer.authorize_url.should == 'https://www.josh.com/uas/oauth/authorize'
+        consumer.token_url.should == 'https://api.josh.com/uas/oauth2/accessToken'
+        consumer.authorize_url.should == 'https://www.josh.com/uas/oauth2/authorization'
       end
     end
 
     describe "different oauth paths" do
       let(:consumer) do
         LinkedIn::Client.new('1234', '1234', {
-          :request_token_path => "/secure/oauth/requestToken",
-          :access_token_path  => "/secure/oauth/accessToken",
-          :authorize_path     => "/secure/oauth/authorize",
+          :token_path     => "/secure/oauth2/accessToken",
+          :authorize_path => "/secure/oauth2/authorization",
         }).consumer
       end
 
       it "should return a configured OAuth consumer" do
         consumer.site.should == 'https://api.linkedin.com'
-        consumer.request_token_url.should == 'https://api.linkedin.com/secure/oauth/requestToken'
-        consumer.access_token_url.should == 'https://api.linkedin.com/secure/oauth/accessToken'
-        consumer.authorize_url.should == 'https://www.linkedin.com/secure/oauth/authorize'
+        consumer.token_url.should == 'https://api.linkedin.com/secure/oauth2/accessToken'
+        consumer.authorize_url.should == 'https://www.linkedin.com/secure/oauth2/authorization'
       end
     end
 
     describe "specify oauth urls" do
       let(:consumer) do
         LinkedIn::Client.new('1234', '1234', {
-          :request_token_url => "https://api.josh.com/secure/oauth/requestToken",
-          :access_token_url  => "https://api.josh.com/secure/oauth/accessToken",
-          :authorize_url     => "https://www.josh.com/secure/oauth/authorize",
+          :token_url     => "https://api.josh.com/secure/oauth2/accessToken",
+          :authorize_url => "https://www.josh.com/secure/oauth2/authorization",
         }).consumer
       end
 
       it "should return a configured OAuth consumer" do
         consumer.site.should == 'https://api.linkedin.com'
-        consumer.request_token_url.should == 'https://api.josh.com/secure/oauth/requestToken'
-        consumer.access_token_url.should == 'https://api.josh.com/secure/oauth/accessToken'
-        consumer.authorize_url.should == 'https://www.josh.com/secure/oauth/authorize'
+        consumer.token_url.should == 'https://api.josh.com/secure/oauth2/accessToken'
+        consumer.authorize_url.should == 'https://www.josh.com/secure/oauth2/authorization'
       end
     end
 
@@ -92,86 +73,21 @@ describe "LinkedIn::Client" do
 
       it "should return a configured OAuth consumer" do
         consumer.site.should == 'https://api.josh.com'
-        consumer.request_token_url.should == 'https://api.josh.com/uas/oauth/requestToken'
-        consumer.access_token_url.should == 'https://api.josh.com/uas/oauth/accessToken'
-        consumer.authorize_url.should == 'https://api.josh.com/uas/oauth/authorize'
+        consumer.token_url.should == 'https://api.josh.com/uas/oauth2/accessToken'
+        consumer.authorize_url.should == 'https://api.josh.com/uas/oauth2/authorization'
       end
-    end
-  end
-
-  describe "#request_token" do
-    vcr_options = { :record => :new_episodes}
-    describe "with default options", vcr: vcr_options do
-
-      it "should return a valid request token" do
-        request_token = client.request_token
-
-        request_token.should be_a_kind_of OAuth::RequestToken
-        request_token.authorize_url.should include("https://www.linkedin.com/uas/oauth/authorize?oauth_token=")
-
-        a_request(:post, "https://api.linkedin.com/uas/oauth/requestToken").should have_been_made.once
-      end
-    end
-
-    describe "with a callback url", vcr: vcr_options do
-
-      it "should return a valid access token" do
-        request_token = client.request_token(:oauth_callback => 'http://www.josh.com')
-
-        request_token.should be_a_kind_of OAuth::RequestToken
-        request_token.authorize_url.should include("https://www.linkedin.com/uas/oauth/authorize?oauth_token=")
-        request_token.callback_confirmed?.should == true
-
-        a_request(:post, "https://api.linkedin.com/uas/oauth/requestToken").should have_been_made.once
-      end
-    end
-  end
-
-  describe "#authorize_from_request" do
-    let(:access_token) do
-      # if you remove the related casssette you will need to do the following
-      # authorize_from_request request manually
-      #
-      # request_token = client.request_token
-      # puts "token    : #{request_token.token} - secret #{request_token.secret}"
-      # puts "auth url : #{request_token.authorize_url}"
-      # raise 'keep note of the token and secret'
-      #
-      client.authorize_from_request('dummy-token', 'dummy-secret', 'dummy-pin')
-    end
-
-    vcr_options = { :record => :new_episodes, :match_requests_on => [ :uri, :method] }
-
-    it "should return a valid access token", vcr: vcr_options do
-      access_token.should be_a_kind_of Array
-      access_token[0].should be_a_kind_of String
-      access_token[1].should be_a_kind_of String
-
-      a_request(:post, "https://api.linkedin.com/uas/oauth/accessToken").should have_been_made.once
     end
   end
 
   describe "#access_token" do
     let(:access_token) do
-      client.authorize_from_access('dummy-token', 'dummy-secret')
+      client.authorize_from_access('dummy-token')
       client.access_token
     end
 
     it "should return a valid auth token" do
-      access_token.should be_a_kind_of OAuth::AccessToken
+      access_token.should be_a_kind_of OAuth2::AccessToken
       access_token.token.should be_a_kind_of String
-    end
-  end
-
-  describe "#authorize_from_access" do
-    let(:auth_token) do
-      client.authorize_from_access('dummy-token', 'dummy-secret')
-    end
-
-    it "should return a valid auth token" do
-      auth_token.should be_a_kind_of Array
-      auth_token[0].should be_a_kind_of String
-      auth_token[1].should be_a_kind_of String
     end
   end
 

--- a/spec/cases/search_spec.rb
+++ b/spec/cases/search_spec.rb
@@ -11,8 +11,7 @@ describe LinkedIn::Search do
     client = LinkedIn::Client.new(consumer_token, consumer_secret)
 
     auth_token      = ENV['LINKED_IN_AUTH_KEY'] || 'key'
-    auth_secret     = ENV['LINKED_IN_AUTH_SECRET'] || 'secret'
-    client.authorize_from_access(auth_token, auth_secret)
+    client.authorize_from_access(auth_token)
     client
   end
 

--- a/spec/fixtures/cassette_library/LinkedIn_Api/Company_API/should_load_correct_company_data.yml
+++ b/spec/fixtures/cassette_library/LinkedIn_Api/Company_API/should_load_correct_company_data.yml
@@ -2,19 +2,21 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.linkedin.com/v1/companies/id=1586
+    uri: https://api.linkedin.com/v1/companies/1586
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      User-Agent:
+      - Faraday v0.9.0
       X-Li-Format:
       - json
-      User-Agent:
-      - OAuth gem v0.4.5
       Authorization:
-      - OAuth oauth_consumer_key="consumer_key", oauth_nonce="nonce", oauth_signature="signature",
-        oauth_signature_method="HMAC-SHA1", oauth_timestamp="1319129843", oauth_token="token",
-        oauth_version="1.0"
+      - Bearer atoken
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
   response:
     status:
       code: 200


### PR DESCRIPTION
I'd be interested in other people trying out this branch and see if it makes sense and works as expected.  I was able to do the requests I was doing before with it.

I used it like this:

```
# Request method
client = LinkedIn::Client.new(ENV["LINKEDIN_API"], ENV["LINKEDIN_SECRET"])
session[:linkedin_state] = SecureRandom.uuid
redirect_to client.authorize_url(redirect_uri: linkedin_auth_callback_url, state: session[:linkedin_state])

# Callback method, should check the state set above on response
client = LinkedIn::Client.new(ENV["LINKEDIN_API"], ENV["LINKEDIN_SECRET"])
token = client.authorize_from_request(params[:code], redirect_uri: linkedin_auth_callback_url)
```
