### PR TITLE
Inherit from LinkedInError

### DIFF
--- a/lib/linked_in/errors.rb
+++ b/lib/linked_in/errors.rb
@@ -18,12 +18,12 @@ module LinkedIn
     class AccessDeniedError      < LinkedInError; end
 
     # Raised when a 404 response status code is received
-    class NotFoundError          < StandardError; end
+    class NotFoundError          < LinkedInError; end
 
     # Raised when a 500 response status code is received
-    class InformLinkedInError    < StandardError; end
+    class InformLinkedInError    < LinkedInError; end
 
     # Raised when a 502 or 503 response status code is received
-    class UnavailableError       < StandardError; end
+    class UnavailableError       < LinkedInError; end
   end
 end


### PR DESCRIPTION
Hi @hexgnu, shouldn't these errors inherits from the `LinkedInError`?