### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Ruby wrapper for the [LinkedIn API](http://developer.linkedin.com). The LinkedIn gem provides an easy-to-use wrapper for LinkedIn's REST APIs.
 
 Travis CI : [![Build Status](https://secure.travis-ci.org/hexgnu/linkedin.png)](http://travis-ci.org/hexgnu/linkedin)
+RapidAPI : [![API Testing](https://img.shields.io/badge/test%20this%20API%20on-RapidAPI.com-blue.svg)](https://rapidapi.com/package/LinkedIn/functions?utm_source=LinkedinGithub&utm_medium=button)
 
 ## Installation
 


### PR DESCRIPTION
I've added a link in your README to Linkedin's functions page in RapidAPI. I've done this for a few Linkedin SDKs to help those who are reading the READMEs, understand and test the API before use.