### PR TITLE
Update LinkedIn::Api::ShareAndSocialStream#add_share for Api v2

### DIFF
--- a/lib/linked_in/api/share_and_social_stream.rb
+++ b/lib/linked_in/api/share_and_social_stream.rb
@@ -82,16 +82,30 @@ module LinkedIn
 
       # Create a share for the authenticated user
       #
-      # Permissions: rw_nus
+      # Permissions: w_member_share
       #
       # @see https://developer.linkedin.com/docs/share-on-linkedin Share API
       #
       # @macro share_input_fields
       # @return [void]
       def add_share(share)
-        path = "/people/~/shares"
-        defaults = {:visibility => {:code => "anyone"}}
-        post(path, MultiJson.dump(defaults.merge(share)), "Content-Type" => "application/json")
+        path = '/ugcPosts'
+        payload = {
+          author: "urn:li:person:#{share[:urn]}",
+          lifecycleState: 'PUBLISHED',
+          specificContent: {
+            'com.linkedin.ugc.ShareContent' => {
+              shareCommentary: { text: share[:comment] },
+              shareMediaCategory: 'NONE'
+            }
+          },
+          visibility: {
+            'com.linkedin.ugc.MemberNetworkVisibility' => 'PUBLIC'
+          }
+        }
+        headers = { "Content-Type" => "application/json",
+                    "X-Restli-Protocol-Version" => "2.0.0" }
+        post(path, MultiJson.dump(payload), headers)
       end
 
       # Create a comment on an update from the authenticated user

--- a/lib/linked_in/helpers/request.rb
+++ b/lib/linked_in/helpers/request.rb
@@ -7,7 +7,7 @@ module LinkedIn
         'x-li-format' => 'json'
       }
 
-      API_PATH = '/v1'
+      API_PATH = '/v2'
 
       protected
 


### PR DESCRIPTION
* The path changed to /v2/ugcPosts
* More attributes are required in the payload

Along with sending over the comment, you must send the user's "urn"

Example:

```
client = LinkedIn::Client.new
client.authorize_from_access(@delivery_method_attributes[:token])
client.add_share({ comment: 'hi', urn: 'urn' })
```

https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/share-on-linkedin?context=linkedin/consumer/context